### PR TITLE
ci: Add basic CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v6
+      with:
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm lint
+    - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "scripts": {
         "serve": "vue-cli-service serve",
         "build": "vue-cli-service build",
-        "lint": "vue-cli-service lint"
+        "lint": "vue-cli-service lint",
+        "test": "npm run lint"
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.3.0",


### PR DESCRIPTION
From the basic Action template ~~, just swapped `test` for `lint`,~~ and removed the Node.js matrix, since multi-version testing isn't likely required